### PR TITLE
fix(utils): rename brand fonts token to `brand`

### DIFF
--- a/packages/aksara-ui-core/src/utils/storybook/SystemHeader.tsx
+++ b/packages/aksara-ui-core/src/utils/storybook/SystemHeader.tsx
@@ -14,7 +14,7 @@ const SystemHeader: React.FC<SystemHeaderProps> = ({ title, subtitle }) => (
       <Box mb={64}>
         <AksaraLogo height={40} />
       </Box>
-      <Heading as="h1" scale={900} color="white" fontFamily="barlow" fontWeight={600} maxWidth={500}>
+      <Heading as="h1" scale={900} color="white" fontFamily="brand" fontWeight={600} maxWidth={500}>
         {title}
       </Heading>
       {typeof subtitle === 'string' ? (

--- a/packages/aksara-ui-core/src/utils/variables.ts
+++ b/packages/aksara-ui-core/src/utils/variables.ts
@@ -241,7 +241,7 @@ export const systemFonts =
 
 export const fonts = {
   system: systemFonts,
-  barlow: `'Barlow', ${systemFonts}`,
+  brand: `'Barlow', ${systemFonts}`,
   monospace: "'SF Mono', Inconsolata, Menlo, Monaco, Consolas, 'Courier New', Courier, monospace;",
 };
 


### PR DESCRIPTION
BREAKING CHANGES: `barlow` font theme token has been renamed to `brand`.