### PR TITLE
fix(reset): remove `!` in modern-normalize header comment

### DIFF
--- a/packages/aksara-ui-core/src/foundations/reset/styles/normalize.ts
+++ b/packages/aksara-ui-core/src/foundations/reset/styles/normalize.ts
@@ -2,7 +2,7 @@ import { css } from 'styled-components';
 
 // prettier-ignore
 const normalize = css`
-  /*! modern-normalize v0.6.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
+  /* modern-normalize v0.6.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
 
   /*
   Document


### PR DESCRIPTION
This should prevent Jest from spitting out the "Could not parse
stylesheet" errors that we keep getting.