### PR TITLE
refactor(button): switch from token sizing to number sizing

### DIFF
--- a/packages/aksara-ui-core/src/components/button/Button.stories.tsx
+++ b/packages/aksara-ui-core/src/components/button/Button.stories.tsx
@@ -442,31 +442,31 @@ export const Example = () => (
         >
           <Box display="flex" flexDirection="column">
             <Heading as="h4" scale={200}>
-              Small
+              Size 32
             </Heading>
             <Box display="flex" flexDirection="column" flex="1 1 auto" mt="sm">
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <Button type="button" variant="primary" size="sm">
+                <Button type="button" variant="primary" size={32}>
                   Push Me
                 </Button>
               </Box>
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <Button type="button" variant="outline" size="sm">
+                <Button type="button" variant="outline" size={32}>
                   Push Me
                 </Button>
               </Box>
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <Button type="button" variant="destructive" size="sm">
+                <Button type="button" variant="destructive" size={32}>
                   Push Me
                 </Button>
               </Box>
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <Button type="button" variant="primary" icon={IconPen} size="sm">
+                <Button type="button" variant="primary" icon={IconPen} size={32}>
                   Push Me
                 </Button>
               </Box>
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <Button type="button" variant="outline" icon={IconPen} size="sm">
+                <Button type="button" variant="outline" icon={IconPen} size={32}>
                   Push Me
                 </Button>
               </Box>
@@ -474,31 +474,31 @@ export const Example = () => (
           </Box>
           <Box display="flex" flexDirection="column">
             <Heading as="h4" scale={200}>
-              Medium
+              Size 40
             </Heading>
             <Box display="flex" flexDirection="column" flex="1 1 auto" mt="sm">
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <Button type="button" variant="primary" size="md">
+                <Button type="button" variant="primary" size={40}>
                   Push Me
                 </Button>
               </Box>
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <Button type="button" variant="outline" size="md">
+                <Button type="button" variant="outline" size={40}>
                   Push Me
                 </Button>
               </Box>
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <Button type="button" variant="destructive" size="md">
+                <Button type="button" variant="destructive" size={40}>
                   Push Me
                 </Button>
               </Box>
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <Button type="button" variant="primary" icon={IconPen} size="md">
+                <Button type="button" variant="primary" icon={IconPen} size={40}>
                   Push Me
                 </Button>
               </Box>
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <Button type="button" variant="outline" icon={IconPen} size="md">
+                <Button type="button" variant="outline" icon={IconPen} size={40}>
                   Push Me
                 </Button>
               </Box>
@@ -516,21 +516,21 @@ export const Example = () => (
         >
           <Box display="flex" flexDirection="column">
             <Heading as="h4" scale={200}>
-              Small
+              Size 32
             </Heading>
             <Box display="flex" flexDirection="column" flex="1 1 auto" mt="sm">
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <LinkButton type="button" variant="primary" size="sm">
+                <LinkButton type="button" variant="primary" size={32}>
                   Push Me
                 </LinkButton>
               </Box>
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <LinkButton type="button" variant="destructive" size="sm">
+                <LinkButton type="button" variant="destructive" size={32}>
                   Push Me
                 </LinkButton>
               </Box>
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <LinkButton type="button" variant="primary" icon={IconPen} size="sm">
+                <LinkButton type="button" variant="primary" icon={IconPen} size={32}>
                   Push Me
                 </LinkButton>
               </Box>
@@ -538,21 +538,21 @@ export const Example = () => (
           </Box>
           <Box display="flex" flexDirection="column">
             <Heading as="h4" scale={200}>
-              Medium
+              Size 40
             </Heading>
             <Box display="flex" flexDirection="column" flex="1 1 auto" mt="sm">
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <LinkButton type="button" variant="primary" size="md">
+                <LinkButton type="button" variant="primary" size={40}>
                   Push Me
                 </LinkButton>
               </Box>
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <LinkButton type="button" variant="destructive" size="md">
+                <LinkButton type="button" variant="destructive" size={40}>
                   Push Me
                 </LinkButton>
               </Box>
               <Box flex="1 1 auto" height="100%" minHeight={72}>
-                <LinkButton type="button" variant="primary" icon={IconPen} size="md">
+                <LinkButton type="button" variant="primary" icon={IconPen} size={40}>
                   Push Me
                 </LinkButton>
               </Box>
@@ -574,20 +574,20 @@ export const AdditionalProps = () => (
         </Button>
       </ComponentBlock>
       <ComponentBlock title="Loading" withBackground>
-        <Button type="button" size="sm" variant="primary" isLoading style={{ marginRight: 16 }}>
+        <Button type="button" size={32} variant="primary" isLoading style={{ marginRight: 16 }}>
           Push Me
         </Button>
-        <Button type="button" size="md" variant="primary" isLoading style={{ marginRight: 16 }}>
+        <Button type="button" size={40} variant="primary" isLoading style={{ marginRight: 16 }}>
           Push Me
         </Button>
-        <Button type="button" size="lg" variant="primary" isLoading>
+        <Button type="button" size={48} variant="primary" isLoading>
           Push Me
         </Button>
       </ComponentBlock>
       <ComponentBlock title="With Icons (left)" withBackground>
         <Button
           type="button"
-          size="sm"
+          size={32}
           variant="primary"
           icon={IconPen}
           iconPosition="left"
@@ -597,7 +597,7 @@ export const AdditionalProps = () => (
         </Button>
         <Button
           type="button"
-          size="md"
+          size={40}
           variant="primary"
           icon={IconPen}
           iconPosition="left"
@@ -605,14 +605,14 @@ export const AdditionalProps = () => (
         >
           Push Me
         </Button>
-        <Button type="button" size="lg" variant="primary" icon={IconPen} iconPosition="left">
+        <Button type="button" size={48} variant="primary" icon={IconPen} iconPosition="left">
           Push Me
         </Button>
       </ComponentBlock>
       <ComponentBlock title="With Icons (right)" withBackground>
         <Button
           type="button"
-          size="sm"
+          size={32}
           variant="primary"
           icon={IconPen}
           iconPosition="right"
@@ -621,7 +621,7 @@ export const AdditionalProps = () => (
           Push Me
         </Button>
         <Button
-          size="md"
+          size={40}
           type="button"
           variant="primary"
           icon={IconPen}
@@ -630,7 +630,7 @@ export const AdditionalProps = () => (
         >
           Push Me
         </Button>
-        <Button size="lg" type="button" variant="primary" icon={IconPen} iconPosition="right">
+        <Button size={48} type="button" variant="primary" icon={IconPen} iconPosition="right">
           Push Me
         </Button>
       </ComponentBlock>
@@ -643,7 +643,7 @@ export const AdditionalProps = () => (
         </Button>
       </ComponentBlock>
       <ComponentBlock title="With Icons loading" withBackground>
-        <Button type="button" isLoading variant="primary" icon={IconPen} size="sm" style={{ marginRight: 16 }}>
+        <Button type="button" isLoading variant="primary" icon={IconPen} size={32} style={{ marginRight: 16 }}>
           Push Me
         </Button>
         <Button type="button" isLoading variant="primary" icon={IconPen}>

--- a/packages/aksara-ui-core/src/components/button/Button.test.tsx
+++ b/packages/aksara-ui-core/src/components/button/Button.test.tsx
@@ -34,7 +34,7 @@ describe('components/Button', () => {
 
     test('renders icons correctly with ReactNode', () => {
       const { container } = render(
-        <Button size="sm" icon={IconDocAdd} iconPosition="right">
+        <Button size={32} icon={IconDocAdd} iconPosition="right">
           test button
         </Button>
       );
@@ -91,10 +91,10 @@ describe('components/Button', () => {
     test('renders in different sizes', () => {
       const { container } = render(
         <>
-          <IconButton size="sm">
+          <IconButton size={32}>
             <i className="icon-trash" />
           </IconButton>
-          <IconButton size="md">
+          <IconButton size={40}>
             <i className="icon-trash" />
           </IconButton>
         </>

--- a/packages/aksara-ui-core/src/components/button/Button.tsx
+++ b/packages/aksara-ui-core/src/components/button/Button.tsx
@@ -31,11 +31,11 @@ interface LoaderCircleProps {
 
 const loadingIconPadding = (size?: ButtonSizes) => {
   switch (size) {
-    case 'lg':
+    case 48:
       return 20;
-    case 'md':
+    case 40:
       return 16;
-    case 'sm':
+    case 32:
       return 12;
     default:
       return 16;
@@ -44,11 +44,11 @@ const loadingIconPadding = (size?: ButtonSizes) => {
 
 const iconPadding = (size?: ButtonSizes) => {
   switch (size) {
-    case 'lg':
+    case 48:
       return 16;
-    case 'md':
+    case 40:
       return 16;
-    case 'sm':
+    case 32:
       return 12;
     default:
       return 16;
@@ -57,11 +57,11 @@ const iconPadding = (size?: ButtonSizes) => {
 
 const loadingIconSizes = (size?: ButtonSizes) => {
   switch (size) {
-    case 'lg':
+    case 48:
       return 40;
-    case 'md':
+    case 40:
       return 32;
-    case 'sm':
+    case 32:
       return 24;
     default:
       return 32;
@@ -158,7 +158,7 @@ Button.defaultProps = {
   icon: undefined,
   iconPosition: 'left',
   variant: 'default',
-  size: 'md',
+  size: 40,
 };
 
 Button.displayName = 'Button';

--- a/packages/aksara-ui-core/src/components/button/FloatingButton.stories.tsx
+++ b/packages/aksara-ui-core/src/components/button/FloatingButton.stories.tsx
@@ -31,30 +31,30 @@ export const Example = () => (
     >
       <Box display="flex" flexDirection="column">
         <Heading as="h4" scale={200} textAlign="center">
-          Small
+          Size 32
         </Heading>
         <Box flex="1 1 auto" textAlign="center" mt="sm">
-          <FloatingButton type="button" size="sm" aria-label="Push Me" onClick={action('button-click')}>
+          <FloatingButton type="button" size={32} aria-label="Push Me" onClick={action('button-click')}>
             <IconPlus fill="currentColor" aria-hidden="true" />
           </FloatingButton>
         </Box>
       </Box>
       <Box display="flex" flexDirection="column">
         <Heading as="h4" scale={200} textAlign="center">
-          Medium
+          Size 40
         </Heading>
         <Box flex="1 1 auto" textAlign="center" mt="sm">
-          <FloatingButton type="button" size="md" aria-label="Push Me" onClick={action('button-click')}>
+          <FloatingButton type="button" size={40} aria-label="Push Me" onClick={action('button-click')}>
             <IconPlus fill="currentColor" aria-hidden="true" />
           </FloatingButton>
         </Box>
       </Box>
       <Box display="flex" flexDirection="column">
         <Heading as="h4" scale={200} textAlign="center">
-          Large
+          Size 48
         </Heading>
         <Box flex="1 1 auto" textAlign="center" mt="sm">
-          <FloatingButton type="button" size="lg" aria-label="Push Me" onClick={action('button-click')}>
+          <FloatingButton type="button" size={48} aria-label="Push Me" onClick={action('button-click')}>
             <IconPlus fill="currentColor" aria-hidden="true" />
           </FloatingButton>
         </Box>

--- a/packages/aksara-ui-core/src/components/button/FloatingButton.stories.tsx
+++ b/packages/aksara-ui-core/src/components/button/FloatingButton.stories.tsx
@@ -51,10 +51,10 @@ export const Example = () => (
       </Box>
       <Box display="flex" flexDirection="column">
         <Heading as="h4" scale={200} textAlign="center">
-          Size 48
+          Size 64
         </Heading>
         <Box flex="1 1 auto" textAlign="center" mt="sm">
-          <FloatingButton type="button" size={48} aria-label="Push Me" onClick={action('button-click')}>
+          <FloatingButton type="button" size={64} aria-label="Push Me" onClick={action('button-click')}>
             <IconPlus fill="currentColor" aria-hidden="true" />
           </FloatingButton>
         </Box>

--- a/packages/aksara-ui-core/src/components/button/FloatingButton.tsx
+++ b/packages/aksara-ui-core/src/components/button/FloatingButton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import { FloatingButtonStyles } from './styles';
-import { FloatingButtonBaseProps, ButtonSizes } from './types';
+import { FloatingButtonBaseProps, FloatingButtonSizes } from './types';
 
 export interface FloatingButtonProps extends FloatingButtonBaseProps, React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Additional CSS classes to give to the component */
@@ -10,7 +10,7 @@ export interface FloatingButtonProps extends FloatingButtonBaseProps, React.Butt
   /** Additional CSS styles to give to the component */
   style?: React.CSSProperties;
   /** The size of the button. */
-  size?: ButtonSizes;
+  size?: FloatingButtonSizes;
 }
 
 const Root = styled('button')<FloatingButtonProps>`

--- a/packages/aksara-ui-core/src/components/button/FloatingButton.tsx
+++ b/packages/aksara-ui-core/src/components/button/FloatingButton.tsx
@@ -33,7 +33,7 @@ FloatingButton.defaultProps = {
   className: undefined,
   style: undefined,
   variant: 'default',
-  size: 'md',
+  size: 40,
 };
 
 FloatingButton.displayName = 'FloatingButton';

--- a/packages/aksara-ui-core/src/components/button/IconButton.stories.tsx
+++ b/packages/aksara-ui-core/src/components/button/IconButton.stories.tsx
@@ -100,7 +100,7 @@ export const ButtonSizes = () => (
       >
         <Box display="flex" flexDirection="column">
           <Heading as="h4" scale={200}>
-            Extra Small
+            Size 24
           </Heading>
           <Box display="flex" flexDirection="column" flex="1 1 auto" mt="sm">
             <Box flex="1 1 auto" height="100%" minHeight={72}>
@@ -108,7 +108,7 @@ export const ButtonSizes = () => (
                 type="button"
                 variant="primary"
                 aria-label="Push Me"
-                size="xs"
+                size={24}
                 onClick={action('button-click')}
               >
                 <IconPen fill="currentColor" aria-hidden="true" />
@@ -119,7 +119,7 @@ export const ButtonSizes = () => (
                 type="button"
                 variant="outline"
                 aria-label="Push Me"
-                size="xs"
+                size={24}
                 onClick={action('button-click')}
               >
                 <IconPen fill="currentColor" aria-hidden="true" />
@@ -130,7 +130,7 @@ export const ButtonSizes = () => (
                 type="button"
                 variant="destructive"
                 aria-label="Push Me"
-                size="xs"
+                size={24}
                 onClick={action('button-click')}
               >
                 <IconPen fill="currentColor" aria-hidden="true" />
@@ -140,14 +140,14 @@ export const ButtonSizes = () => (
         </Box>
         <Box display="flex" flexDirection="column">
           <Heading as="h4" scale={200}>
-            Small
+            Size 32
           </Heading>
           <Box display="flex" flexDirection="column" flex="1 1 auto" mt="sm">
             <Box flex="1 1 auto" height="100%" minHeight={72}>
               <IconButton
                 type="button"
                 aria-label="Push Me"
-                size="sm"
+                size={32}
                 variant="primary"
                 onClick={action('button-click')}
               >
@@ -158,7 +158,7 @@ export const ButtonSizes = () => (
               <IconButton
                 type="button"
                 aria-label="Push Me"
-                size="sm"
+                size={32}
                 variant="outline"
                 onClick={action('button-click')}
               >
@@ -169,7 +169,7 @@ export const ButtonSizes = () => (
               <IconButton
                 type="button"
                 aria-label="Push Me"
-                size="sm"
+                size={32}
                 variant="destructive"
                 onClick={action('button-click')}
               >
@@ -180,14 +180,14 @@ export const ButtonSizes = () => (
         </Box>
         <Box display="flex" flexDirection="column">
           <Heading as="h4" scale={200}>
-            Medium
+            Size 40
           </Heading>
           <Box display="flex" flexDirection="column" flex="1 1 auto" mt="sm">
             <Box flex="1 1 auto" height="100%" minHeight={72}>
               <IconButton
                 type="button"
                 aria-label="Push Me"
-                size="md"
+                size={40}
                 variant="primary"
                 onClick={action('button-click')}
               >
@@ -198,7 +198,7 @@ export const ButtonSizes = () => (
               <IconButton
                 type="button"
                 aria-label="Push Me"
-                size="md"
+                size={40}
                 variant="outline"
                 onClick={action('button-click')}
               >
@@ -209,7 +209,7 @@ export const ButtonSizes = () => (
               <IconButton
                 type="button"
                 aria-label="Push Me"
-                size="md"
+                size={40}
                 variant="destructive"
                 onClick={action('button-click')}
               >

--- a/packages/aksara-ui-core/src/components/button/OutlineButton.stories.tsx
+++ b/packages/aksara-ui-core/src/components/button/OutlineButton.stories.tsx
@@ -24,7 +24,7 @@ export const Example = () => (
     <SystemSubheading mb="xl">Default Theme</SystemSubheading>
     <Stack spacing="xl">
       <ComponentBlock title="Default Button" withBackground>
-        <OutlineButton type="button" style={{ marginRight: 16 }} size="sm" onClick={action('button-click')}>
+        <OutlineButton type="button" style={{ marginRight: 16 }} size={32} onClick={action('button-click')}>
           Push Me
         </OutlineButton>
         <OutlineButton type="button" style={{ marginRight: 16 }} onClick={action('button-click')}>
@@ -36,7 +36,7 @@ export const Example = () => (
           type="button"
           variant="primary"
           style={{ marginRight: 16 }}
-          size="sm"
+          size={32}
           onClick={action('button-click')}
         >
           Push Me
@@ -50,7 +50,7 @@ export const Example = () => (
           type="button"
           variant="success"
           style={{ marginRight: 16 }}
-          size="sm"
+          size={32}
           onClick={action('button-click')}
         >
           Push Me
@@ -64,7 +64,7 @@ export const Example = () => (
           type="button"
           variant="warning"
           style={{ marginRight: 16 }}
-          size="sm"
+          size={32}
           onClick={action('button-click')}
         >
           Push Me
@@ -78,7 +78,7 @@ export const Example = () => (
           type="button"
           variant="destructive"
           style={{ marginRight: 16 }}
-          size="sm"
+          size={32}
           onClick={action('button-click')}
         >
           Push Me
@@ -190,7 +190,7 @@ export const AdditionalProps = () => (
         </OutlineButton>
       </ComponentBlock>
       <ComponentBlock title="Loading" withBackground>
-        <OutlineButton type="button" size="sm" variant="primary" isLoading style={{ marginRight: 16 }}>
+        <OutlineButton type="button" size={32} variant="primary" isLoading style={{ marginRight: 16 }}>
           Push Me
         </OutlineButton>
         <OutlineButton type="button" variant="primary" isLoading>
@@ -200,7 +200,7 @@ export const AdditionalProps = () => (
       <ComponentBlock title="With Icons (left)" withBackground>
         <OutlineButton
           type="button"
-          size="sm"
+          size={32}
           variant="primary"
           icon={IconPen}
           iconPosition="left"
@@ -215,7 +215,7 @@ export const AdditionalProps = () => (
       <ComponentBlock title="With Icons (right)" withBackground>
         <OutlineButton
           type="button"
-          size="sm"
+          size={32}
           variant="primary"
           icon={IconPen}
           iconPosition="right"
@@ -236,7 +236,7 @@ export const AdditionalProps = () => (
         </OutlineButton>
       </ComponentBlock>
       <ComponentBlock title="With Icons loading" withBackground>
-        <OutlineButton type="button" isLoading variant="primary" icon={IconPen} size="sm" style={{ marginRight: 16 }}>
+        <OutlineButton type="button" isLoading variant="primary" icon={IconPen} size={32} style={{ marginRight: 16 }}>
           Push Me
         </OutlineButton>
         <OutlineButton type="button" isLoading variant="primary" icon={IconPen}>

--- a/packages/aksara-ui-core/src/components/button/OutlineButton.tsx
+++ b/packages/aksara-ui-core/src/components/button/OutlineButton.tsx
@@ -30,11 +30,11 @@ interface LoaderCircleProps {
 
 const loadingIconPadding = (size?: ButtonSizes) => {
   switch (size) {
-    case 'lg':
+    case 48:
       return 20;
-    case 'md':
+    case 40:
       return 16;
-    case 'sm':
+    case 32:
       return 12;
     default:
       return 16;
@@ -43,11 +43,11 @@ const loadingIconPadding = (size?: ButtonSizes) => {
 
 const loadingIconSizes = (size?: ButtonSizes) => {
   switch (size) {
-    case 'lg':
+    case 48:
       return 40;
-    case 'md':
+    case 40:
       return 32;
-    case 'sm':
+    case 32:
       return 24;
     default:
       return 32;
@@ -141,7 +141,7 @@ OutlineButton.defaultProps = {
   icon: undefined,
   iconPosition: 'left',
   variant: 'default',
-  size: 'md',
+  size: 40,
 };
 
 OutlineButton.displayName = 'OutlineButton';

--- a/packages/aksara-ui-core/src/components/button/components/LinkButton/LinkButton.tsx
+++ b/packages/aksara-ui-core/src/components/button/components/LinkButton/LinkButton.tsx
@@ -12,9 +12,9 @@ export interface LinkButtonProps extends LinkButtonBaseProps, React.ButtonHTMLAt
 
 const loadingIconPadding = (size?: LinkButtonSizes) => {
   switch (size) {
-    case 'md':
+    case 40:
       return 16;
-    case 'sm':
+    case 32:
       return 12;
     default:
       return 16;
@@ -23,9 +23,9 @@ const loadingIconPadding = (size?: LinkButtonSizes) => {
 
 const loadingIconSizes = (size?: LinkButtonSizes) => {
   switch (size) {
-    case 'md':
+    case 40:
       return 32;
-    case 'sm':
+    case 32:
       return 24;
     default:
       return 32;
@@ -97,7 +97,7 @@ const LinkButton = React.forwardRef<HTMLButtonElement, LinkButtonProps>(
 
 LinkButton.defaultProps = {
   variant: 'primary',
-  size: 'md',
+  size: 40,
   iconPosition: 'left',
 };
 

--- a/packages/aksara-ui-core/src/components/button/components/LinkButton/styles.tsx
+++ b/packages/aksara-ui-core/src/components/button/components/LinkButton/styles.tsx
@@ -14,7 +14,7 @@ import {
 } from './variants';
 
 export type LinkButtonVariants = 'primary' | 'destructive' | 'inverse';
-export type LinkButtonSizes = 'sm' | 'md';
+export type LinkButtonSizes = 32 | 40;
 
 export interface LinkButtonBaseProps extends Omit<ButtonBaseProps, 'size' | 'block' | 'variant'> {
   variant?: LinkButtonVariants;

--- a/packages/aksara-ui-core/src/components/button/components/LinkButton/variants.ts
+++ b/packages/aksara-ui-core/src/components/button/components/LinkButton/variants.ts
@@ -58,13 +58,13 @@ export const linkButtonDisabledVariants = {
 };
 
 export const linkButtonSizeVariants = {
-  sm: {
+  32: {
     height: '32px',
     fontSize: componentStyles.text[300].fontSize,
     lineHeight: componentStyles.text[300].lineHeight,
     borderRadius: radii.sm,
   },
-  md: {
+  40: {
     height: '40px',
     fontSize: componentStyles.text[300].fontSize,
     lineHeight: componentStyles.text[300].lineHeight,

--- a/packages/aksara-ui-core/src/components/button/styles.ts
+++ b/packages/aksara-ui-core/src/components/button/styles.ts
@@ -98,9 +98,9 @@ export const FloatingButtonStyles = (props: FloatingButtonBaseProps) => css`
     opacity: 0.5;
   }
 
-  ${props.buttonSize === 'sm' && FloatingButtonSmall}
-  ${props.buttonSize === 'md' && FloatingButtonMedium}
-  ${props.buttonSize === 'lg' && FloatingButtonLarge}
+  ${props.buttonSize === 32 && FloatingButtonSmall}
+  ${props.buttonSize === 40 && FloatingButtonMedium}
+  ${props.buttonSize === 48 && FloatingButtonLarge}
 
   ${props.variant === 'primary' && FloatingButtonPrimary}
   ${props.variant === 'success' && FloatingButtonSuccess}
@@ -153,9 +153,9 @@ export const ButtonStyles = (props: ButtonBaseProps) => css`
   ${props.variant === 'ghost' && ButtonGhost}
   ${props.variant === 'inverse' && InverseButton}
 
-  ${props.buttonSize === 'sm' && ButtonSmall(props)}
-  ${props.buttonSize === 'md' && ButtonMedium(props)}
-  ${props.buttonSize === 'lg' && ButtonLarge(props)}
+  ${props.buttonSize === 32 && ButtonSmall(props)}
+  ${props.buttonSize === 40 && ButtonMedium(props)}
+  ${props.buttonSize === 48 && ButtonLarge(props)}
 `;
 
 export const OutlineButtonStyles = (props: OutlineButtonBaseProps) => css`
@@ -194,7 +194,7 @@ export const OutlineButtonStyles = (props: OutlineButtonBaseProps) => css`
   ${props.variant === 'warning' && OutlineButtonWarning}
   ${props.variant === 'destructive' && OutlineButtonDestructive}
 
-  ${props.buttonSize === 'sm' && OutlineButtonSmall(props)}
-  ${props.buttonSize === 'md' && OutlineButtonMedium(props)}
-  ${props.buttonSize === 'lg' && OutlineButtonLarge(props)}
+  ${props.buttonSize === 32 && OutlineButtonSmall(props)}
+  ${props.buttonSize === 40 && OutlineButtonMedium(props)}
+  ${props.buttonSize === 48 && OutlineButtonLarge(props)}
 `;

--- a/packages/aksara-ui-core/src/components/button/styles.ts
+++ b/packages/aksara-ui-core/src/components/button/styles.ts
@@ -100,7 +100,7 @@ export const FloatingButtonStyles = (props: FloatingButtonBaseProps) => css`
 
   ${props.buttonSize === 32 && FloatingButtonSmall}
   ${props.buttonSize === 40 && FloatingButtonMedium}
-  ${props.buttonSize === 48 && FloatingButtonLarge}
+  ${props.buttonSize === 64 && FloatingButtonLarge}
 
   ${props.variant === 'primary' && FloatingButtonPrimary}
   ${props.variant === 'success' && FloatingButtonSuccess}

--- a/packages/aksara-ui-core/src/components/button/types.ts
+++ b/packages/aksara-ui-core/src/components/button/types.ts
@@ -4,8 +4,8 @@ export type ButtonVariants = 'default' | 'primary' | 'outline' | 'destructive' |
 export type FloatingButtonVariants = 'default' | 'primary' | 'success' | 'warning' | 'destructive';
 export type OutlineButtonVariants = 'default' | 'primary' | 'success' | 'warning' | 'destructive';
 export type IconButtonVariants = 'default' | 'primary' | 'outline' | 'destructive' | 'ghost';
-export type ButtonSizes = 'sm' | 'md' | 'lg';
-export type IconButtonSizes = 'xs' | 'sm' | 'md';
+export type ButtonSizes = 32 | 40 | 48;
+export type IconButtonSizes = 24 | 32 | 40;
 export type ButtonIconPositions = 'left' | 'right';
 
 type AllButtonStyledProps = LayoutProps & PositionProps & FlexboxProps & GridProps & SpaceProps;

--- a/packages/aksara-ui-core/src/components/button/types.ts
+++ b/packages/aksara-ui-core/src/components/button/types.ts
@@ -6,6 +6,7 @@ export type OutlineButtonVariants = 'default' | 'primary' | 'success' | 'warning
 export type IconButtonVariants = 'default' | 'primary' | 'outline' | 'destructive' | 'ghost';
 export type ButtonSizes = 32 | 40 | 48;
 export type IconButtonSizes = 24 | 32 | 40;
+export type FloatingButtonSizes = 32 | 40 | 64;
 export type ButtonIconPositions = 'left' | 'right';
 
 type AllButtonStyledProps = LayoutProps & PositionProps & FlexboxProps & GridProps & SpaceProps;
@@ -40,7 +41,7 @@ export interface FloatingButtonBaseProps extends AllButtonStyledProps {
   /** The variant of the button. */
   variant?: FloatingButtonVariants;
   /** The size of the button. `size` is reserved by styled-system, so we alias its type. */
-  buttonSize?: ButtonSizes;
+  buttonSize?: FloatingButtonSizes;
 }
 
 export interface IconButtonBaseProps extends AllButtonStyledProps {

--- a/packages/aksara-ui-core/src/components/button/utils/floatingButtonUtils.ts
+++ b/packages/aksara-ui-core/src/components/button/utils/floatingButtonUtils.ts
@@ -1,14 +1,14 @@
 import { css } from 'styled-components';
 import { colors } from '../../../utils';
-import { ButtonSizes } from '../types';
+import { FloatingButtonSizes } from '../types';
 
-export function floatingButtonSizes(size?: ButtonSizes) {
+export function floatingButtonSizes(size?: FloatingButtonSizes) {
   switch (size) {
-    case 'lg':
+    case 64:
       return 64;
-    case 'md':
+    case 40:
       return 40;
-    case 'sm':
+    case 32:
       return 32;
     default:
       return 40;

--- a/packages/aksara-ui-core/src/components/button/utils/iconButtonUtils.ts
+++ b/packages/aksara-ui-core/src/components/button/utils/iconButtonUtils.ts
@@ -4,25 +4,16 @@ import { colors } from '../../../utils/variables';
 import { IconButtonSizes } from '../types';
 
 export function iconButtonSizes(size?: IconButtonSizes) {
-  switch (size) {
-    case 'md':
-      return 40;
-    case 'sm':
-      return 32;
-    case 'xs':
-      return 24;
-    default:
-      return 32;
-  }
+  return size || 32;
 }
 
 export function iconSizes(size?: IconButtonSizes) {
   switch (size) {
-    case 'md':
+    case 40:
       return 24;
-    case 'sm':
+    case 32:
       return 16;
-    case 'xs':
+    case 24:
       return 12;
     default:
       return 20;

--- a/packages/aksara-ui-core/src/foundations/card/index.stories.tsx
+++ b/packages/aksara-ui-core/src/foundations/card/index.stories.tsx
@@ -293,12 +293,12 @@ export const Example2 = () => (
         </Box>
         <Box>
           <Tooltip placement="top" content="View" style={{ display: 'inline-block', marginRight: 8 }}>
-            <IconButton type="button" size="md" variant="ghost">
+            <IconButton type="button" size={40} variant="ghost">
               <IconInfo aria-hidden fill="currentColor" />
             </IconButton>
           </Tooltip>
           <Tooltip placement="top" content="Rollback" style={{ display: 'inline-block' }}>
-            <IconButton type="button" size="md" variant="destructive">
+            <IconButton type="button" size={40} variant="destructive">
               <IconTrash aria-hidden fill="currentColor" />
             </IconButton>
           </Tooltip>


### PR DESCRIPTION
BREAKING CHANGES: Button now uses number-based size props instead of
token-based size props.