### PR TITLE
feat(blankslate): add additional blankslate variants

### DIFF
--- a/packages/aksara-ui-core/src/components/blankslate/components/Blankslate.stories.tsx
+++ b/packages/aksara-ui-core/src/components/blankslate/components/Blankslate.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-import { SystemWrapper, SystemBlock } from '../../../utils/storybook';
+import { SystemWrapper, SystemBlock, SystemSubheading } from '../../../utils/storybook';
 
-import { Paragraph, Anchor } from '../../../foundations';
+import { Paragraph, Anchor, Stack } from '../../../foundations';
 import Blankslate from './Blankslate';
 
 const readme = require('../README.md');
@@ -18,14 +18,29 @@ export default {
 
 export const BasicExample = () => (
   <SystemBlock title="Blankslate" subtitle="Used to provide additional information when no dynamic content exists.">
-    <Blankslate
-      image={<img src="https://via.placeholder.com/528x352.png" alt="Create a model" />}
-      title="Create a model"
-    >
-      <Paragraph color="grey07">
-        Perform specific text analysis tasks, like detecting topics, extracting specific words, and more.{' '}
-        <Anchor href="#">Learn more</Anchor>
-      </Paragraph>
-    </Blankslate>
+    <Stack spacing="lg">
+      <Stack spacing="md">
+        <SystemSubheading>Page level</SystemSubheading>
+        <Blankslate
+          image={<img src="https://via.placeholder.com/528x352.png" alt="Create a model" />}
+          title="Create a model"
+          variant="page"
+          content={
+            <Paragraph color="grey07">
+              Perform specific text analysis tasks, like detecting topics, extracting specific words, and more.{' '}
+              <Anchor href="#">Learn more</Anchor>
+            </Paragraph>
+          }
+        />
+      </Stack>
+      <Stack spacing="md">
+        <SystemSubheading>Inner level</SystemSubheading>
+        <Blankslate
+          variant="inner"
+          image={<img src="https://via.placeholder.com/120x120.png" alt="Create a model" />}
+          content="No data yet."
+        />
+      </Stack>
+    </Stack>
   </SystemBlock>
 );

--- a/packages/aksara-ui-core/src/components/blankslate/components/Blankslate.test.tsx
+++ b/packages/aksara-ui-core/src/components/blankslate/components/Blankslate.test.tsx
@@ -4,9 +4,16 @@ import Blankslate from './Blankslate';
 
 describe('components/Blankslate', () => {
   test('renders with title', () => {
-    const { getByText } = render(<Blankslate title="Empty Text">Board test</Blankslate>);
+    const { getByText } = render(<Blankslate variant="page" title="Empty Text" content="Blankslate test" />);
 
     const title = getByText('Empty Text');
     expect(title).toBeInTheDocument();
+  });
+
+  test("doesn't render title in inner variant", () => {
+    const { queryByText } = render(<Blankslate variant="inner" title="Empty Text" content="Blankslate test" />);
+
+    const title = queryByText(/Empty Text/);
+    expect(title).not.toBeInTheDocument();
   });
 });

--- a/packages/aksara-ui-core/src/components/blankslate/components/Blankslate.tsx
+++ b/packages/aksara-ui-core/src/components/blankslate/components/Blankslate.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
-import { Box, Heading } from '../../../foundations';
+import { Box, Heading, Paragraph } from '../../../foundations';
 
 const ImageWrapper = styled(Box)`
   position: relative;
@@ -18,26 +18,58 @@ export interface BlankslateProps {
   className?: string;
   /** Additional CSS styles to give to the component. */
   style?: React.CSSProperties;
+  /** Variant of the blankslate component. Can be `page` or `inner`. */
+  variant: 'page' | 'inner';
   /** The title of the non-ideal state. */
-  title: string;
+  title?: string;
   /** Render any image inside the image block up to 155px height. */
   image?: React.ReactNode;
+  /** Blankslate text content. */
+  content: React.ReactNode;
 }
 
-const Blankslate: React.FC<BlankslateProps> = ({ className, style, image, title, children }) => {
+const BlankslateWrapper: React.FC<Pick<BlankslateProps, 'className' | 'style'>> = ({ className, style, children }) => {
   return (
     <Box className={className} style={style} mx="auto" my="xxl" width="100%" maxWidth="528px" textAlign="center">
-      {image && <ImageWrapper mb={60}>{image}</ImageWrapper>}
-      <Heading scale={600} mt={0} mb="lg">
-        {title}
-      </Heading>
-      <Box>{children}</Box>
+      {children}
     </Box>
   );
 };
 
-Blankslate.defaultProps = {
-  image: undefined,
+const Blankslate: React.FC<BlankslateProps> = ({ className, style, variant, image, title, content, children }) => {
+  const renderContent = () => {
+    if (children) {
+      console.warn('Using `children` has been deprecated in favour of the `content` prop. Please use that instead.');
+      return children;
+    }
+
+    if (typeof content === 'string') {
+      return <Paragraph color="grey07">{content}</Paragraph>;
+    }
+
+    return content;
+  };
+
+  if (variant === 'inner') {
+    return (
+      <BlankslateWrapper className={className} style={style}>
+        {image && <ImageWrapper mb="md">{image}</ImageWrapper>}
+        <Box>{renderContent()}</Box>
+      </BlankslateWrapper>
+    );
+  }
+
+  return (
+    <BlankslateWrapper className={className} style={style}>
+      {image && <ImageWrapper mb="md">{image}</ImageWrapper>}
+      {title && (
+        <Heading scale={600} mt={0} mb="lg">
+          {title}
+        </Heading>
+      )}
+      <Box>{renderContent()}</Box>
+    </BlankslateWrapper>
+  );
 };
 
 Blankslate.displayName = 'Blankslate';


### PR DESCRIPTION
New blankslate variants:

- Page level (`variant="page"`)
- Inner level (`variant="inner"`)

Fixes #243.