### PR TITLE
fix(tooltip): use proper z-index on tooltip wrapper

### DIFF
--- a/packages/aksara-ui-core/src/components/tooltip/components/TooltipInner.tsx
+++ b/packages/aksara-ui-core/src/components/tooltip/components/TooltipInner.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { variant } from 'styled-system';
 import { themeGet } from '@styled-system/theme-get';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import * as popper from 'popper.js';
+import * as popper from '@popperjs/core';
 
-import { colors, space } from '../../../utils';
-import { Text, Paragraph } from '../../../foundations';
+import { colors } from '../../../utils';
+import { Text, Paragraph, Box } from '../../../foundations';
 
 export type TooltipPlacement = popper.Placement;
 export type TooltipSize = 'sm' | 'md' | 'lg';
@@ -18,40 +17,6 @@ export interface TooltipInnerProps extends React.HTMLAttributes<HTMLDivElement> 
   placement?: TooltipPlacement;
   size?: TooltipSize;
 }
-
-function determineMargins(placement?: TooltipPlacement) {
-  switch (placement) {
-    case 'top': {
-      return css`
-        padding-bottom: ${space.xxs}px;
-      `;
-    }
-    case 'right': {
-      return css`
-        padding-left: ${space.xxs}px;
-      `;
-    }
-    case 'bottom': {
-      return css`
-        padding-top: ${space.xxs}px;
-      `;
-    }
-    case 'left': {
-      return css`
-        padding-right: ${space.xxs}px;
-      `;
-    }
-    default: {
-      return css`
-        padding-bottom: ${space.xxs}px;
-      `;
-    }
-  }
-}
-
-const Root = styled('div')<Pick<TooltipInnerProps, 'placement'>>`
-  ${props => determineMargins(props.placement)}
-`;
 
 const Inner = styled('div')<Omit<TooltipInnerProps, 'placement' | 'content'>>`
   ${variant({
@@ -80,7 +45,7 @@ const Inner = styled('div')<Omit<TooltipInnerProps, 'placement' | 'content'>>`
   background-color: ${themeGet('colors.grey09', colors.grey09)};
 `;
 
-const TooltipInner: React.RefForwardingComponent<HTMLDivElement, TooltipInnerProps> = (
+const TooltipInner: React.ForwardRefRenderFunction<HTMLDivElement, TooltipInnerProps> = (
   { className, style, content, size, placement, ...rest },
   ref
 ) => {
@@ -101,9 +66,9 @@ const TooltipInner: React.RefForwardingComponent<HTMLDivElement, TooltipInnerPro
   };
 
   return (
-    <Root className={className} style={style} ref={ref} placement={placement} {...rest}>
+    <Box p="xxs" zIndex={9999} className={className} style={style} ref={ref} data-placement={placement} {...rest}>
       <Inner size={size}>{renderContent()}</Inner>
-    </Root>
+    </Box>
   );
 };
 


### PR DESCRIPTION
Fixes the issue where the tooltip sometimes appears behind an element
with a higher z-index.

Fixes #287.