### PR TITLE
refactor: allow passing pseudo + `sx` props in more components

### DIFF
--- a/packages/aksara-ui-core/src/foundations/common/components/UnstyledAnchor/UnstyledAnchor.tsx
+++ b/packages/aksara-ui-core/src/foundations/common/components/UnstyledAnchor/UnstyledAnchor.tsx
@@ -1,38 +1,16 @@
 import styled from 'styled-components';
 import {
-  layout,
-  LayoutProps,
-  position,
-  PositionProps,
-  flexbox,
-  FlexboxProps,
-  grid,
-  GridProps,
-  space,
-  SpaceProps,
-  background,
-  BackgroundProps,
-  color,
-  ColorProps,
-  typography,
-  TypographyProps,
-  border,
-  BorderProps,
-  shadow,
-  ShadowProps,
-} from 'styled-system';
+  allSystemProps,
+  AllSystemProps,
+  pseudoSystemProps,
+  PseudoSystemProps,
+  shouldForwardProp,
+  sxMixin,
+  SxProps,
+  componentStylesMixin,
+} from '../../../../system';
 
-export interface UnstyledAnchorProps
-  extends LayoutProps,
-    PositionProps,
-    FlexboxProps,
-    GridProps,
-    SpaceProps,
-    BackgroundProps,
-    ColorProps,
-    TypographyProps,
-    BorderProps,
-    ShadowProps {
+export interface UnstyledAnchorProps extends AllSystemProps, PseudoSystemProps, SxProps {
   /**
    * Extended color props. We need this because default `color` prop clashes with `styled-system`.
    */
@@ -40,50 +18,12 @@ export interface UnstyledAnchorProps
 }
 
 /** An anchor element with all styling elements removed (incl. hover/focus effects). */
-const UnstyledAnchor = styled('a')<UnstyledAnchorProps>`
-  font-style: inherit;
-  color: inherit;
-  background-color: transparent;
-  font-size: inherit;
-  text-decoration: none;
-  font-variant: inherit;
-  font-weight: inherit;
-  line-height: inherit;
-  font-family: inherit;
-  border-radius: inherit;
-  border: inherit;
-  outline: inherit;
-  box-shadow: inherit;
-
-  &:hover,
-  &:focus,
-  &:active {
-    font-style: inherit;
-    color: inherit;
-    background-color: transparent;
-    font-size: inherit;
-    text-decoration: none;
-    font-variant: inherit;
-    font-weight: inherit;
-    line-height: inherit;
-    font-family: inherit;
-    border-radius: inherit;
-    border: inherit;
-    outline: inherit;
-    box-shadow: inherit;
-  }
-
-  ${layout}
-  ${position}
-  ${flexbox}
-  ${grid}
-  ${space}
-  ${background}
-  ${color}
-  ${typography}
-  ${border}
-  ${shadow}
-`;
+const UnstyledAnchor = styled('a').withConfig<UnstyledAnchorProps>({ shouldForwardProp })(
+  componentStylesMixin('unstyledAnchor'),
+  allSystemProps,
+  pseudoSystemProps,
+  sxMixin
+);
 
 UnstyledAnchor.displayName = 'UnstyledAnchor';
 

--- a/packages/aksara-ui-core/src/foundations/common/components/UnstyledButton/UnstyledButton.tsx
+++ b/packages/aksara-ui-core/src/foundations/common/components/UnstyledButton/UnstyledButton.tsx
@@ -1,40 +1,16 @@
 import styled from 'styled-components';
 import {
-  ButtonStyleProps,
-  layout,
-  LayoutProps,
-  position,
-  PositionProps,
-  flexbox,
-  FlexboxProps,
-  grid,
-  GridProps,
-  space,
-  SpaceProps,
-  background,
-  BackgroundProps,
-  color,
-  ColorProps,
-  typography,
-  TypographyProps,
-  border,
-  BorderProps,
-  shadow,
-  ShadowProps,
-} from 'styled-system';
+  allSystemProps,
+  AllSystemProps,
+  pseudoSystemProps,
+  PseudoSystemProps,
+  shouldForwardProp,
+  sxMixin,
+  SxProps,
+  componentStylesMixin,
+} from '../../../../system';
 
-export interface UnstyledButtonProps
-  extends ButtonStyleProps,
-    LayoutProps,
-    PositionProps,
-    FlexboxProps,
-    GridProps,
-    SpaceProps,
-    BackgroundProps,
-    ColorProps,
-    TypographyProps,
-    BorderProps,
-    ShadowProps {
+export interface UnstyledButtonProps extends AllSystemProps, PseudoSystemProps, SxProps {
   /**
    * Extended color props. We need this because default `color` prop clashes with `styled-system`.
    */
@@ -42,44 +18,12 @@ export interface UnstyledButtonProps
 }
 
 /** A button element with all styling elements removed (incl. hover/focus effects). */
-const UnstyledButton = styled('button')<UnstyledButtonProps>`
-  width: auto;
-  margin: 0;
-  padding: 0;
-  border: none;
-  font: inherit;
-  color: inherit;
-  background-color: transparent;
-  cursor: pointer;
-
-  /* Normalizes line height & removes center align */
-  line-height: normal;
-  text-align: inherit;
-
-  /* Corrects font smoothing for webkit */
-  -webkit-font-smoothing: inherit;
-  -moz-osx-font-smoothing: inherit;
-
-  /* Corrects inability to style clickable \`input\` types in iOS */
-  -webkit-appearance: none;
-
-  /* Remove excess padding and border in Firefox 4+ */
-  &::-moz-focus-inner {
-    border: 0;
-    padding: 0;
-  }
-
-  ${layout}
-  ${position}
-  ${flexbox}
-  ${grid}
-  ${space}
-  ${background}
-  ${color}
-  ${typography}
-  ${border}
-  ${shadow}
-`;
+const UnstyledButton = styled('button').withConfig<UnstyledButtonProps>({ shouldForwardProp })(
+  componentStylesMixin('unstyledButton'),
+  allSystemProps,
+  pseudoSystemProps,
+  sxMixin
+);
 
 UnstyledButton.displayName = 'UnstyledButton';
 

--- a/packages/aksara-ui-core/src/theme/componentStyles/button.ts
+++ b/packages/aksara-ui-core/src/theme/componentStyles/button.ts
@@ -1,0 +1,37 @@
+import { ComponentThemeConfig } from '../types';
+
+export const unstyledButton: ComponentThemeConfig = {
+  baseStyle: () => ({
+    width: 'auto',
+    margin: 0,
+    padding: 0,
+    border: 'none',
+    font: 'inherit',
+    color: 'inherit',
+    backgroundColor: 'transparent',
+    cursor: 'pointer',
+
+    // Normalizes line height & removes center align
+    lineHeight: 'normal',
+    textAlign: 'inherit',
+
+    // Corrects font smoothing for webkit
+    '-webkit-font-smoothing': 'inherit',
+    '-moz-osx-font-smoothing': 'inherit',
+
+    // Corrects inability to style clickable \`input\` types in iOS
+    '-webkit-appearance': 'none',
+
+    // Remove excess padding and border in Firefox 4+
+    '&::-moz-focus-inner': {
+      border: 0,
+      padding: 0,
+    },
+  }),
+};
+
+const button = {
+  unstyledButton,
+};
+
+export default button;

--- a/packages/aksara-ui-core/src/theme/componentStyles/index.ts
+++ b/packages/aksara-ui-core/src/theme/componentStyles/index.ts
@@ -1,8 +1,9 @@
 import avatar from './avatar';
 import badge from './badge';
+import button from './button';
 import card from './card';
 import pill from './pill';
-import { anchor } from './typography';
+import typography from './typography';
 
 /**
  * Custom theme props based on custom component variants.
@@ -10,9 +11,10 @@ import { anchor } from './typography';
 const componentStyles = {
   avatar,
   badge,
+  ...button,
   card,
-  anchor,
   pill,
+  ...typography,
 };
 
 export default componentStyles;

--- a/packages/aksara-ui-core/src/theme/componentStyles/typography.ts
+++ b/packages/aksara-ui-core/src/theme/componentStyles/typography.ts
@@ -16,8 +16,42 @@ export const anchor: ComponentThemeConfig = {
   }),
 };
 
+export const unstyledAnchor: ComponentThemeConfig = {
+  baseStyle: () => ({
+    fontStyle: 'inherit',
+    color: 'inherit',
+    backgroundColor: 'transparent',
+    fontSize: 'inherit',
+    textDecoration: 'none',
+    fontVariant: 'inherit',
+    fontWeight: 'inherit',
+    lineHeight: 'inherit',
+    fontFamily: 'inherit',
+    borderRadius: 'inherit',
+    border: 'inherit',
+    outline: 'inherit',
+    boxShadow: 'inherit',
+    '&:hover, &:focus, &:active': {
+      fontStyle: 'inherit',
+      color: 'inherit',
+      backgroundColor: 'transparent',
+      fontSize: 'inherit',
+      textDecoration: 'none',
+      fontVariant: 'inherit',
+      fontWeight: 'inherit',
+      lineHeight: 'inherit',
+      fontFamily: 'inherit',
+      borderRadius: 'inherit',
+      border: 'inherit',
+      outline: 'inherit',
+      boxShadow: 'inherit',
+    },
+  }),
+};
+
 const typography = {
   anchor,
+  unstyledAnchor,
 };
 
 export default typography;


### PR DESCRIPTION
Allow passing pseudo + `sx` props in these components:

- `UnstyledButton`
- `UnstyledAnchor`