### PR TITLE
refactor: deprecated `FormGroup` and `Inline`

### DIFF
--- a/packages/aksara-ui-core/src/components/form/components/FormGroup/FormGroup.tsx
+++ b/packages/aksara-ui-core/src/components/form/components/FormGroup/FormGroup.tsx
@@ -1,21 +1,24 @@
 import * as React from 'react';
-import styled from 'styled-components';
-import { theme } from '../../../../theme';
+import { Stack, StackProps } from '../../../../layout';
 
-export interface FormGroupProps {
+export interface FormGroupProps extends StackProps {
   /** Additional CSS classes to give to the component. */
   className?: string;
+  /** Additional CSS properties to give to the component. */
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
 }
 
-const Div = styled('div')`
-  margin-bottom: ${theme.space.md}px;
-
-  &:last-of-type {
-    margin-bottom: 0;
-  }
-`;
-
-const FormGroup: React.FC<FormGroupProps> = ({ className, children }) => <Div className={className}>{children}</Div>;
+/**
+ * @deprecated use `<Stack spacing="xs" />` instead.
+ */
+const FormGroup = React.forwardRef<HTMLDivElement, FormGroupProps>(({ className, style, children, ...rest }, ref) => {
+  return (
+    <Stack ref={ref} spacing="xs" className={className} style={style} {...rest}>
+      {children}
+    </Stack>
+  );
+});
 
 FormGroup.displayName = 'FormGroup';
 

--- a/packages/aksara-ui-core/src/layout/inline/Inline.tsx
+++ b/packages/aksara-ui-core/src/layout/inline/Inline.tsx
@@ -16,33 +16,39 @@ export interface InlineProps extends Omit<BoxProps, 'color'>, SpacingProps {
   className?: string;
   style?: React.CSSProperties;
   color?: string;
+  children?: React.ReactNode;
 }
 
-const Inline: React.FC<InlineProps> = ({ children, spacing = 'sm', alignItems, ...rest }) => {
-  const theme = useTheme();
-  const validChildrenArray = React.Children.toArray(children).filter(React.isValidElement);
+/**
+ * @deprecated This component will soon be replaced with `<Stack direction="row" />`
+ */
+const Inline = React.forwardRef<HTMLDivElement, InlineProps>(
+  ({ children, spacing = 'sm', alignItems, ...rest }, ref) => {
+    const theme = useTheme();
+    const validChildrenArray = React.Children.toArray(children).filter(React.isValidElement);
 
-  const negativeSpacing = React.useMemo(() => `-${get(theme, `space.${spacing}`, 0)}px`, [theme]);
+    const negativeSpacing = React.useMemo(() => `-${get(theme, `space.${spacing}`, 0)}px`, [theme]);
 
-  return (
-    <Box marginTop={negativeSpacing} {...rest}>
-      <Box display="flex" flexWrap="wrap" alignItems={alignItems} marginLeft={negativeSpacing}>
-        {validChildrenArray.map((child, i) => {
-          const spacingProps = { mt: spacing, ml: spacing, mb: 0, mr: 0 };
-          if (typeof child === 'string' || child.type === React.Fragment) {
-            return (
-              <Box key={`inline-child-${i}`} {...spacingProps}>
-                {child}
-              </Box>
-            );
-          }
+    return (
+      <Box ref={ref} marginTop={negativeSpacing} {...rest}>
+        <Box display="flex" flexWrap="wrap" alignItems={alignItems} marginLeft={negativeSpacing}>
+          {validChildrenArray.map((child, i) => {
+            const spacingProps = { mt: spacing, ml: spacing, mb: 0, mr: 0 };
+            if (typeof child === 'string' || child.type === React.Fragment) {
+              return (
+                <Box key={`inline-child-${i}`} {...spacingProps}>
+                  {child}
+                </Box>
+              );
+            }
 
-          return React.cloneElement(child, spacingProps);
-        })}
+            return React.cloneElement(child, spacingProps);
+          })}
+        </Box>
       </Box>
-    </Box>
-  );
-};
+    );
+  }
+);
 
 Inline.displayName = 'Inline';
 

--- a/packages/aksara-ui-core/src/layout/stack/Stack.tsx
+++ b/packages/aksara-ui-core/src/layout/stack/Stack.tsx
@@ -12,13 +12,14 @@ export interface StackProps extends Omit<BoxProps, 'color'> {
   style?: React.CSSProperties;
   color?: string;
   spacing?: Space;
+  children?: React.ReactNode;
 }
 
-const Stack: React.FC<StackProps> = ({ children, spacing, ...rest }) => {
+const Stack = React.forwardRef<HTMLDivElement, StackProps>(({ children, spacing, ...rest }, ref) => {
   const validChildrenArray = React.Children.toArray(children).filter(React.isValidElement);
 
   return (
-    <Box {...rest}>
+    <Box ref={ref} {...rest}>
       {validChildrenArray.map((child, i) => {
         const isLastChild = validChildrenArray.length === i + 1;
         const spacingProps = { mb: isLastChild ? 0 : spacing };
@@ -34,7 +35,7 @@ const Stack: React.FC<StackProps> = ({ children, spacing, ...rest }) => {
       })}
     </Box>
   );
-};
+});
 
 Stack.displayName = 'Stack';
 


### PR DESCRIPTION
Deprecated the following components:

- `FormGroup` - use `<Stack spacing="xs" />` instead.
- `Inline` - This component will soon be replaced with `<Stack direction="row" />`