### PR TITLE
refactor(react): export portal props type from radix

### DIFF
--- a/packages/react/src/helpers/portal/components/Portal.tsx
+++ b/packages/react/src/helpers/portal/components/Portal.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import * as PortalPrimitive from '@radix-ui/react-portal';
 
-const Portal: React.FC<PortalPrimitive.PortalProps> = ({ children, ...rest }) => {
+export type PortalProps = PortalPrimitive.PortalProps;
+
+const Portal: React.FC<PortalProps> = ({ children, ...rest }) => {
   return <PortalPrimitive.Root {...rest}>{children}</PortalPrimitive.Root>;
 };
 

--- a/packages/react/src/helpers/portal/index.ts
+++ b/packages/react/src/helpers/portal/index.ts
@@ -1,2 +1,2 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as Portal } from './components/Portal';
+export * from './components/Portal';


### PR DESCRIPTION
## Description

Export `PortalProps` type from `radix-ui` into the package.
