### PR TITLE
refactor(react): migrate `Popover` to `radix-ui`

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@aksara-ui/core": "^1.0.1-canary.2",
-    "@popperjs/core": "^2.10.2",
     "@radix-ui/react-id": "^0.1.1",
+    "@radix-ui/react-popover": "^0.1.1",
     "@radix-ui/react-portal": "^0.1.1",
     "@radix-ui/react-tooltip": "^0.1.1",
     "@radix-ui/react-visually-hidden": "^0.1.1",
@@ -51,7 +51,6 @@
     "focus-trap": "^6.6.0",
     "polished": "^4.1.3",
     "react-fast-compare": "^3.2.0",
-    "react-popper": "^2.2.5",
     "react-ranger": "^2.1.0",
     "react-transition-group": "^4.4.2",
     "styled-system": "^5.1.4",

--- a/packages/react/src/components/popover/components/Popover.stories.tsx
+++ b/packages/react/src/components/popover/components/Popover.stories.tsx
@@ -63,6 +63,6 @@ export const Example: Story<PopoverProps> = ({ placement }) => {
   );
 };
 Example.args = {
-  placement: 'bottom',
+  placement: 'top',
   align: 'center',
 };

--- a/packages/react/src/components/popover/components/Popover.stories.tsx
+++ b/packages/react/src/components/popover/components/Popover.stories.tsx
@@ -64,4 +64,5 @@ export const Example: Story<PopoverProps> = ({ placement }) => {
 };
 Example.args = {
   placement: 'bottom',
+  align: 'center',
 };

--- a/packages/react/src/components/popover/components/Popover.stories.tsx
+++ b/packages/react/src/components/popover/components/Popover.stories.tsx
@@ -11,23 +11,10 @@ export default {
   component: Popover,
   argTypes: {
     placement: {
-      options: [
-        'auto',
-        'auto-start',
-        'auto-end',
-        'top',
-        'top-start',
-        'top-end',
-        'bottom',
-        'bottom-start',
-        'bottom-end',
-        'left',
-        'left-start',
-        'left-end',
-        'right',
-        'right-start',
-        'right-end',
-      ],
+      options: ['top', 'bottom', 'left', 'right'],
+    },
+    align: {
+      options: ['start', 'center', 'end'],
     },
   },
 } as Meta<PopoverProps>;
@@ -43,7 +30,7 @@ export const Example: Story<PopoverProps> = ({ placement }) => {
       height={640}
     >
       <Popover placement={placement} trigger={<Button variant="primary">Toggle Popover</Button>}>
-        <Box>
+        <Box width="100%" maxWidth={300}>
           <Box py="md" px="lg" borderBottom="1px solid" borderBottomColor="greylight04">
             <Heading scale={300}>Add agent to your team</Heading>
           </Box>

--- a/packages/react/src/components/popover/components/Popover.test.tsx
+++ b/packages/react/src/components/popover/components/Popover.test.tsx
@@ -24,7 +24,7 @@ describe('components/Popover', () => {
       const triggerButton = getByRole('button', { name: /toggle popover/i });
       fireEvent.click(triggerButton);
 
-      expect(queryByText(/This is a popover/)).toBeVisible();
+      expect(queryByText(/This is a popover/)).toBeInTheDocument();
     });
   });
 });

--- a/packages/react/src/components/popover/components/Popover.tsx
+++ b/packages/react/src/components/popover/components/Popover.tsx
@@ -17,9 +17,6 @@ export interface PopoverProps extends PopoverPrimitive.PopoverProps, SxProps {
   align?: PopoverPrimitive.PopoverContentProps['align'];
 }
 
-// TODO: Clicking outside popover should also hide it
-// TODO: Rewrite into `react-popper` hooks API
-// https://popper.js.org/react-popper/v2/hook/
 const Popover: React.FC<PopoverProps> = ({
   className,
   style,

--- a/packages/react/src/components/popover/components/Popover.tsx
+++ b/packages/react/src/components/popover/components/Popover.tsx
@@ -1,42 +1,21 @@
 import * as React from 'react';
-import styled from 'styled-components';
-import clsx from 'clsx';
-import * as CSS from 'csstype';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { Placement } from '@popperjs/core';
-import { Manager, Reference, Popper } from 'react-popper';
 import { Box } from '../../../layout';
-import { Portal } from '../../../helpers';
+import { SxProps, useComponentStyles } from '../../../system';
 
-export interface PopoverProps {
+export interface PopoverProps extends PopoverPrimitive.PopoverProps, SxProps {
+  /** Classname to pass to the popover content. */
   className?: string;
+  /** CSS properties to pass to the popover content. */
   style?: React.CSSProperties;
-  summaryClassName?: string;
-  summaryStyle?: React.CSSProperties;
-  width?: CSS.Property.Width;
-  maxWidth?: CSS.Property.MaxWidth;
-  maxHeight?: CSS.Property.MaxHeight;
+  /** The element which triggers the popover content. */
   trigger: React.ReactElement;
-  children: React.ReactElement;
-  placement?: Placement;
+  /** Popover placement. Uses the `side` props from `radix-ui` */
+  placement?: PopoverPrimitive.PopoverContentProps['side'];
+  /** Popover alignment. Uses the `alignment` props from `radix-ui` */
+  align?: PopoverPrimitive.PopoverContentProps['align'];
 }
-
-const Arrow = styled(Box)`
-  height: 20px;
-  position: absolute;
-  width: 20px;
-  pointer-events: none;
-
-  &::after {
-    content: '';
-    position: absolute;
-    width: 0;
-    height: 0;
-    border-width: 10px;
-    border-style: solid;
-    border-color: transparent;
-  }
-`;
 
 // TODO: Clicking outside popover should also hide it
 // TODO: Rewrite into `react-popper` hooks API
@@ -44,106 +23,28 @@ const Arrow = styled(Box)`
 const Popover: React.FC<PopoverProps> = ({
   className,
   style,
+  sx,
   trigger,
   children,
-  width,
-  maxWidth = 320,
-  maxHeight,
+  defaultOpen,
+  open,
+  onOpenChange,
+  modal,
   placement = 'bottom',
+  align = 'center',
 }) => {
-  const [isVisible, setIsVisible] = React.useState(false);
+  const popoverContentStyles = useComponentStyles('popoverContent');
 
   return (
-    <Manager>
-      <Reference>
-        {({ ref }) => {
-          const innerClassName = clsx(trigger.props.className, isVisible && 'active');
-
-          return React.cloneElement(trigger, {
-            className: innerClassName,
-            ref,
-            role: 'button',
-            onClick: () => {
-              setIsVisible(!isVisible);
-            },
-          });
-        }}
-      </Reference>
-      <Portal>
-        {isVisible && (
-          <Popper placement={placement}>
-            {({ ref, style: menuStyle, placement: innerPlacement, arrowProps }) => {
-              const innerStyle = { ...children.props.style, ...menuStyle };
-              return (
-                <Box
-                  className={className}
-                  style={{ ...innerStyle, ...style }}
-                  sx={{
-                    backgroundColor: 'greylight01',
-                    borderRadius: 12,
-                    boxShadow: 4,
-                    width,
-                    maxWidth,
-                    maxHeight,
-                    zIndex: 1000,
-                    '&[data-placement*="bottom"]': {
-                      marginTop: 'md',
-                    },
-                    '&[data-placement*="top"]': {
-                      marginBottom: 'md',
-                    },
-                    '&[data-placement*="right"]': {
-                      marginLeft: 'md',
-                    },
-                    '&[data-placement*="left"]': {
-                      marginRight: 'md',
-                    },
-                  }}
-                  ref={ref}
-                  data-placement={innerPlacement}
-                >
-                  {children}
-                  <Arrow
-                    data-placement={innerPlacement}
-                    sx={{
-                      '&[data-placement*="bottom"]': {
-                        top: 0,
-                        marginTop: -18,
-                        '&::after': {
-                          borderBottomColor: 'greylight01',
-                        },
-                      },
-                      '&[data-placement*="top"]': {
-                        bottom: 0,
-                        marginBottom: -18,
-                        '&::after': {
-                          borderTopColor: 'greylight01',
-                        },
-                      },
-                      '&[data-placement*="right"]': {
-                        left: 0,
-                        marginLeft: -18,
-                        '&::after': {
-                          borderRightColor: 'greylight01',
-                        },
-                      },
-                      '&[data-placement*="left"]': {
-                        right: 0,
-                        marginRight: -18,
-                        '&::after': {
-                          borderLeftColor: 'greylight01',
-                        },
-                      },
-                    }}
-                    {...arrowProps}
-                  />
-                </Box>
-              );
-            }}
-          </Popper>
-        )}
-      </Portal>
-    </Manager>
+    <PopoverPrimitive.Root defaultOpen={defaultOpen} open={open} onOpenChange={onOpenChange} modal={modal}>
+      <PopoverPrimitive.Trigger asChild>{trigger}</PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Content asChild side={placement} sideOffset={8} align={align}>
+        <Box className={className} style={style} sx={{ ...popoverContentStyles, ...sx }}>
+          {children}
+          <PopoverPrimitive.Arrow offset={22} width={20} height={8} fill="var(--popover-border)" />
+        </Box>
+      </PopoverPrimitive.Content>
+    </PopoverPrimitive.Root>
   );
 };
 

--- a/packages/react/src/components/tooltip/components/TooltipInner.tsx
+++ b/packages/react/src/components/tooltip/components/TooltipInner.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import * as popper from '@popperjs/core';
 
 import { Box } from '../../../layout';
 import { useComponentStyles } from '../../../system';
 import { Text, Paragraph } from '../../../typography';
 
-export type TooltipPlacement = popper.Placement;
 export type TooltipSize = 'sm' | 'md' | 'lg';
 
 export interface TooltipInnerProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/packages/react/src/theme/componentStyles/index.ts
+++ b/packages/react/src/theme/componentStyles/index.ts
@@ -7,6 +7,7 @@ import form from './form';
 import message from './message';
 import navigation from './navigation';
 import pill from './pill';
+import popover from './popover';
 import slider from './slider';
 import stepper from './stepper';
 import typography from './typography';
@@ -29,6 +30,7 @@ const componentStyles = {
   ...message,
   ...navigation,
   ...pill,
+  ...popover,
   ...slider,
   ...stepper,
   ...subHeader,

--- a/packages/react/src/theme/componentStyles/popover.ts
+++ b/packages/react/src/theme/componentStyles/popover.ts
@@ -1,0 +1,22 @@
+import type { DefaultTheme } from 'styled-components';
+import { ComponentThemeConfig } from '../../system';
+
+const popoverContent: ComponentThemeConfig = {
+  baseStyle: ({ theme }: { theme: DefaultTheme }) => ({
+    '--popover-border': theme.colors.greylight01,
+    '--popover-background': theme.colors.greylight01,
+    backgroundColor: 'var(--popover-background)',
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: 'var(--popover-border)',
+    borderRadius: 12,
+    boxShadow: 4,
+    zIndex: 1000,
+  }),
+};
+
+const popover = {
+  popoverContent,
+};
+
+export default popover;

--- a/packages/react/test/setupTests.ts
+++ b/packages/react/test/setupTests.ts
@@ -1,4 +1,6 @@
-/* eslint-disable @typescript-eslint/ban-ts-ignore */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable class-methods-use-this */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable import/no-extraneous-dependencies */
 import '@testing-library/jest-dom/extend-expect';
@@ -17,3 +19,32 @@ if (global.document) {
     },
   });
 }
+
+// https://github.com/radix-ui/primitives/issues/420#issuecomment-771615182
+global.ResizeObserver = class ResizeObserver {
+  cb: any;
+
+  constructor(cb: any) {
+    this.cb = cb;
+  }
+
+  observe() {
+    this.cb([{ borderBoxSize: { inlineSize: 0, blockSize: 0 } }]);
+  }
+
+  unobserve() {}
+
+  disconnect() {}
+};
+
+window.DOMRect = {
+  // @ts-ignore
+  fromRect: () => ({
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    width: 0,
+    height: 0,
+  }),
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,11 +2953,6 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@popperjs/core@^2.10.2":
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
-  integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
-
 "@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
   version "2.9.3"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.3.tgz#8b68da1ebd7fc603999cf6ebee34a4899a14b88e"
@@ -3000,6 +2995,36 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-dismissable-layer@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.1.1.tgz#1be9d1c6945b27a69dfd6742928904a526d1d345"
+  integrity sha512-OrwRfYE3dqX6nbCnAcIaxsTg6QrLu/HT1GwzxpX0Mbx+AxFNBvE6czBTM5/a7D1CfK8jxORNZ/WsjoOTLudY+A==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "0.1.0"
+    "@radix-ui/react-context" "0.1.1"
+    "@radix-ui/react-primitive" "0.1.1"
+    "@radix-ui/react-use-body-pointer-events" "0.1.0"
+    "@radix-ui/react-use-callback-ref" "0.1.0"
+    "@radix-ui/react-use-escape-keydown" "0.1.0"
+
+"@radix-ui/react-focus-guards@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-0.1.0.tgz#ba3b6f902cba7826569f8edc21ff8223dece7def"
+  integrity sha512-kRx/swAjEfBpQ3ns7J3H4uxpXuWCqN7MpALiSDOXiyo2vkWv0L9sxvbpZeTulINuE3CGMzicVMuNc/VWXjFKOg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-focus-scope@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-0.1.1.tgz#2639a2abd268bc435348313cfd90026241deb58c"
+  integrity sha512-0b9MwvHwhuIhD46lrf4G2j53/oYzPa2hN9Ylu+4Jg0Qa0kW04/vpKCX2Gh8M8fTlI0YaGVQsN40sYc5fe8RBSA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "0.1.0"
+    "@radix-ui/react-primitive" "0.1.1"
+    "@radix-ui/react-use-callback-ref" "0.1.0"
+
 "@radix-ui/react-id@0.1.1", "@radix-ui/react-id@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-0.1.1.tgz#42c8f3967875e6824b2ac9d49c66317047c8d6ff"
@@ -3007,6 +3032,27 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-context" "0.1.1"
+
+"@radix-ui/react-popover@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-0.1.1.tgz#99951e10d70c3855b7a7db52f7f15af684e47848"
+  integrity sha512-kPcuzpB72MQMbnLg24NR4NgOLRL7so5/ApukDKGQqGXs/ZBtAUBTdtNSnQIyItT4rvoRbtUOOIH0jC7072yFMg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "0.1.0"
+    "@radix-ui/react-compose-refs" "0.1.0"
+    "@radix-ui/react-context" "0.1.1"
+    "@radix-ui/react-dismissable-layer" "0.1.1"
+    "@radix-ui/react-focus-guards" "0.1.0"
+    "@radix-ui/react-focus-scope" "0.1.1"
+    "@radix-ui/react-id" "0.1.1"
+    "@radix-ui/react-popper" "0.1.1"
+    "@radix-ui/react-portal" "0.1.1"
+    "@radix-ui/react-presence" "0.1.1"
+    "@radix-ui/react-primitive" "0.1.1"
+    "@radix-ui/react-use-controllable-state" "0.1.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "^2.4.0"
 
 "@radix-ui/react-popper@0.1.1":
   version "0.1.1"
@@ -3078,6 +3124,14 @@
     "@radix-ui/react-use-previous" "0.1.0"
     "@radix-ui/react-use-rect" "0.1.1"
     "@radix-ui/react-visually-hidden" "0.1.1"
+
+"@radix-ui/react-use-body-pointer-events@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.1.0.tgz#29b211464493f8ca5149ce34b96b95abbc97d741"
+  integrity sha512-svPyoHCcwOq/vpWNEvdH/yD91vN9p8BtiozNQbjVmJRxQ/vS12zqk70AxTGWe+2ZKHq2sggpEQNTv1JHyVFlnQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "0.1.0"
 
 "@radix-ui/react-use-callback-ref@0.1.0":
   version "0.1.0"
@@ -5330,6 +5384,13 @@ argv@0.0.2:
   resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
   integrity sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=
 
+aria-hidden@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.1.3.tgz#bb48de18dc84787a3c6eee113709c473c64ec254"
+  integrity sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==
+  dependencies:
+    tslib "^1.0.0"
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -7508,6 +7569,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
 detect-port-alt@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.6.tgz#24707deabe932d4a3cf621302027c2b266568275"
@@ -9134,6 +9200,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
@@ -14189,7 +14260,7 @@ react-popper-tooltip@^3.1.1:
     "@popperjs/core" "^2.5.4"
     react-popper "^2.2.4"
 
-react-popper@^2.2.4, react-popper@^2.2.5:
+react-popper@^2.2.4:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
   integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
@@ -14206,6 +14277,25 @@ react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-remove-scroll-bar@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz#d4d545a7df024f75d67e151499a6ab5ac97c8cdd"
+  integrity sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==
+  dependencies:
+    react-style-singleton "^2.1.0"
+    tslib "^1.0.0"
+
+react-remove-scroll@^2.4.0:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.4.3.tgz#83d19b02503b04bd8141ed6e0b9e6691a2e935a6"
+  integrity sha512-lGWYXfV6jykJwbFpsuPdexKKzp96f3RbvGapDSIdcyGvHb7/eqyn46C7/6h+rUzYar1j5mdU+XECITHXCKBk9Q==
+  dependencies:
+    react-remove-scroll-bar "^2.1.0"
+    react-style-singleton "^2.1.0"
+    tslib "^1.0.0"
+    use-callback-ref "^1.2.3"
+    use-sidecar "^1.0.1"
 
 react-select@^3.2.0:
   version "3.2.0"
@@ -14230,6 +14320,15 @@ react-sizeme@^3.0.1:
     invariant "^2.2.4"
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
+
+react-style-singleton@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.1.1.tgz#ce7f90b67618be2b6b94902a30aaea152ce52e66"
+  integrity sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==
+  dependencies:
+    get-nonce "^1.0.0"
+    invariant "^2.2.4"
+    tslib "^1.0.0"
 
 react-syntax-highlighter@^13.5.3:
   version "13.5.3"
@@ -16376,7 +16475,7 @@ tslib@2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.0.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -16745,6 +16844,11 @@ urlgrey@1.0.0:
   dependencies:
     fast-url-parser "^1.1.3"
 
+use-callback-ref@^1.2.3:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.5.tgz#6115ed242cfbaed5915499c0a9842ca2912f38a5"
+  integrity sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==
+
 use-composed-ref@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/use-composed-ref/-/use-composed-ref-1.1.0.tgz#9220e4e94a97b7b02d7d27eaeab0b37034438bbc"
@@ -16763,6 +16867,14 @@ use-latest@^1.0.0:
   integrity sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
+
+use-sidecar@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.5.tgz#ffff2a17c1df42e348624b699ba6e5c220527f2b"
+  integrity sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^1.9.3"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Closes #495
Closes #496

## Description

Migrates `Popover` to `radix-ui` to fix all the issues

## Current Tasks

<!-- (Optional) List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review. -->

- [x] Migrate `Popover` to `radix-ui`
- [x] Fix all testing issues
