### PR TITLE
refactor(toast): move `ToastProvider` outside of internals

### DIFF
--- a/packages/react/src/aksara-provider/AksaraProvider.tsx
+++ b/packages/react/src/aksara-provider/AksaraProvider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { IdProvider } from '@radix-ui/react-id';
 import { ThemeProvider } from 'styled-components';
-import { ToastProvider } from '../components/toast/internals';
+import { ToastProvider } from '../components/toast';
 
 import { theme as defaultTheme, Theme } from '../theme';
 import injectGlobalStyles from './injectGlobalStyles';

--- a/packages/react/src/components/toast/README.md
+++ b/packages/react/src/components/toast/README.md
@@ -1,0 +1,21 @@
+# Toast
+
+> Displays toast notification to show feedback to dynamic data.
+
+## Usage
+
+To use this component in your app, import as follows:
+
+```tsx
+import { useToast } from '@aksara-ui/react';
+
+export default function Component() {
+  const { addToast } = useToast();
+
+  return <button onClick={() => addToast({ message: 'This is a toast!' })}>Show toast</button>;
+}
+```
+
+## API
+
+TBA

--- a/packages/react/src/components/toast/ToastProvider.tsx
+++ b/packages/react/src/components/toast/ToastProvider.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { ToastSettings } from '../types';
-import ToastContainer from './ToastContainer';
-import ToastContext from './ToastContext';
+import { ToastSettings } from './types';
+import { ToastContainer, ToastContext } from './internals';
 
 let toastCount = 0;
 

--- a/packages/react/src/components/toast/index.ts
+++ b/packages/react/src/components/toast/index.ts
@@ -1,2 +1,3 @@
 export { default as useToast } from './useToast';
+export { default as ToastProvider } from './ToastProvider';
 export * from './types';

--- a/packages/react/src/components/toast/internals/index.ts
+++ b/packages/react/src/components/toast/internals/index.ts
@@ -1,2 +1,3 @@
 export { default as ToastContext } from './ToastContext';
-export { default as ToastProvider } from './ToastProvider';
+export { default as ToastContainer } from './ToastContainer';
+export * from './constants';


### PR DESCRIPTION
## Description

Move `ToastProvider` outside of internals in preparation of requiring users to import `ToastProvider` explicitly.
