### PR TITLE
fix(react): fixed input select scroll overflow

### DIFF
--- a/packages/react/src/components/form/components/InputSelect/InputSelect.tsx
+++ b/packages/react/src/components/form/components/InputSelect/InputSelect.tsx
@@ -127,7 +127,7 @@ function InputSelect<T>({
           p={0}
           m={0}
           maxHeight={maxHeight}
-          overflowY="scroll"
+          overflowY="auto"
           {...getMenuProps()}
         >
           {items && items.length !== 0 ? (


### PR DESCRIPTION
## Description

Use `overflow: auto` instead of `overflow: scroll` to prevent unintended scroller.